### PR TITLE
修改了一些内容

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Dc1Server
+Dc1Server
+
+项目Fork自ZXQ-Kyle/Dc1Server
+
+DC1插座复活的服务器端
+
+修改了如下：
+1.查询间隔由1分钟改为5秒,以便于实时观察功率变化,会增加网络传输
+2.将ConnectionManager中的mDeviceConnectionMap的key由ip改为ip+port,以解决将server部署到云服务器,同一路由器下的DC1 ip相同,mDeviceConnectionMap覆盖重复查询问题
+3.新增心跳检测,15秒未通讯关闭channel
+4.关闭channel时,将DC1 online置为false,以便客户端显示离线状态
+
+感谢原作者.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Dc1Server
 Dc1Server
 
-项目Fork自ZXQ-Kyle/Dc1Server
+##### 项目Fork自ZXQ-Kyle/Dc1Server
 
-DC1插座复活的服务器端
 
-修改了如下：
-1.查询间隔由1分钟改为5秒,以便于实时观察功率变化,会增加网络传输
-2.将ConnectionManager中的mDeviceConnectionMap的key由ip改为ip+port,以解决将server部署到云服务器,同一路由器下的DC1 ip相同,mDeviceConnectionMap覆盖重复查询问题
-3.新增心跳检测,15秒未通讯关闭channel
-4.关闭channel时,将DC1 online置为false,以便客户端显示离线状态
+## DC1插座复活的服务器端
 
-感谢原作者.
+修改了如下： 
+#### 1.查询间隔由1分钟改为5秒,以便于实时观察功率变化,会增加网络传输 
+#### 2.将ConnectionManager中的mDeviceConnectionMap的key由ip改为ip+port,以解决将server部署到云服务器,同一路由器下的DC1 ip相同,mDeviceConnectionMap覆盖重复查询问题 2.将ConnectionManager中的mDeviceConnectionMap的key由ip改为ip+port,以解决将server部署到云服务器,同一路由器下的DC1 ip相同,mDeviceConnectionMap覆盖重复查询问题 
+#### 3.新增心跳检测,15秒未通讯关闭channel
+#### 4.关闭channel时,将DC1 online置为false,以便客户端显示离线状态
+
+
+### 感谢原作者.

--- a/src/main/java/space/ponyo/dc1/server/server/ConnectionManager.java
+++ b/src/main/java/space/ponyo/dc1/server/server/ConnectionManager.java
@@ -41,7 +41,7 @@ public class ConnectionManager {
         int localPort = localAddress.getPort();
         if (localPort == 8800) {
             //手机连接
-            PhoneConnection connection = mPhoneConnectionMap.get(ip);
+            PhoneConnection connection = mPhoneConnectionMap.get(ip + ":" + remotePort);
             if (connection == null) {
                 connection = new PhoneConnection();
                 mPhoneConnectionMap.put(ip + ":" + remotePort, connection);

--- a/src/main/java/space/ponyo/dc1/server/server/ConnectionManager.java
+++ b/src/main/java/space/ponyo/dc1/server/server/ConnectionManager.java
@@ -75,6 +75,7 @@ public class ConnectionManager {
             if (mDeviceConnectionMap.get(ip + ":" + remotePort).isActive()) {
                 return;
             }
+            DataPool.offline(mDeviceConnectionMap.get(ip + ":" + remotePort).getId());
             mDeviceConnectionMap.remove(ip + ":" + remotePort);
         }
     }

--- a/src/main/java/space/ponyo/dc1/server/server/ConnectionManager.java
+++ b/src/main/java/space/ponyo/dc1/server/server/ConnectionManager.java
@@ -29,7 +29,7 @@ public class ConnectionManager {
         if (localPort == 8800) {
             executorService.execute(() -> mPhoneConnectionMap.get(ip + ":" + remotePort).processMessage(msg));
         } else {
-            executorService.execute(() -> mDeviceConnectionMap.get(ip).processMessage(msg));
+            executorService.execute(() -> mDeviceConnectionMap.get(ip + ":" + remotePort).processMessage(msg));
         }
     }
 
@@ -52,7 +52,7 @@ public class ConnectionManager {
             DeviceConnection connection = mDeviceConnectionMap.get(ip);
             if (connection == null) {
                 connection = new DeviceConnection();
-                mDeviceConnectionMap.put(ip, connection);
+                mDeviceConnectionMap.put(ip + ":" + remotePort, connection);
             }
             connection.setChannel(channel);
             return connection;
@@ -72,10 +72,10 @@ public class ConnectionManager {
             }
             mPhoneConnectionMap.remove(ip + ":" + remotePort);
         } else {
-            if (mDeviceConnectionMap.get(ip).isActive()) {
+            if (mDeviceConnectionMap.get(ip + ":" + remotePort).isActive()) {
                 return;
             }
-            mDeviceConnectionMap.remove(ip);
+            mDeviceConnectionMap.remove(ip + ":" + remotePort);
         }
     }
 

--- a/src/main/java/space/ponyo/dc1/server/server/DeviceConnection.java
+++ b/src/main/java/space/ponyo/dc1/server/server/DeviceConnection.java
@@ -97,7 +97,7 @@ public class DeviceConnection implements IConnection {
                 }.getType();
                 AskBean<ActivateBean> askBean = gson.fromJson(msg, type);
                 id = askBean.getParams().getMac();
-                sendMessageScheduleThread.scheduleWithFixedDelay(new QueryTask(), 0, 1, TimeUnit.MINUTES);
+                sendMessageScheduleThread.scheduleWithFixedDelay(new QueryTask(), 0, 5, TimeUnit.SECONDS);
             } else if (msg.contains(IDENTIFY)) {
                 //收到dc1上线数据 第二种数据格式
                 Type type = new TypeToken<AskBean<IdentifyBean>>() {
@@ -110,7 +110,7 @@ public class DeviceConnection implements IConnection {
                         .setStatus(200)
                         .setMsg("device identified");
                 appendMsgToQueue(gson.toJson(answerBean));
-                sendMessageScheduleThread.scheduleWithFixedDelay(new QueryTask(), 0, 1, TimeUnit.MINUTES);
+                sendMessageScheduleThread.scheduleWithFixedDelay(new QueryTask(), 0, 5, TimeUnit.SECONDS);
             } else if (msg.contains(DETAL_KWH)) {
                 //收到用电量增加
                 Type type = new TypeToken<AskBean<DetalKwhBean>>() {

--- a/src/main/java/space/ponyo/dc1/server/server/NettySocketServer.java
+++ b/src/main/java/space/ponyo/dc1/server/server/NettySocketServer.java
@@ -81,6 +81,7 @@ public class NettySocketServer {
 //            pipeline.addLast(new DelimiterBasedFrameDecoder(1024 * 1024, Delimiters.lineDelimiter()));
             pipeline.addLast(new LineBasedFrameDecoder(1024 * 1024));
             pipeline.addLast(new IdleStateHandler(15, 15, 15));
+             pipeline.addLast(new HeartBeatServerHandler());
             pipeline.addLast("handler", new ServerHandler());//服务器处理客户端请求
         }
     }
@@ -115,6 +116,17 @@ public class NettySocketServer {
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             ctx.close();
             super.exceptionCaught(ctx, cause);
+        }
+    }
+    
+     public static class HeartBeatServerHandler extends ChannelInboundHandlerAdapter {
+        private int lossConnectCount = 0;
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            System.out.println("已经15秒未收到客户端的消息了！close");
+            ctx.channel().close();
+
         }
     }
 }


### PR DESCRIPTION
1.查询间隔由1分钟改为5秒,以便于实时观察功率变化,会增加网络传输 
2.将ConnectionManager中的mDeviceConnectionMap的key由ip改为ip+port,以解决将server部署到云服务器,同一路由器下的DC1 ip相同,mDeviceConnectionMap覆盖重复查询问题 2.将ConnectionManager中的mDeviceConnectionMap的key由ip改为ip+port,以解决将server部署到云服务器,同一路由器下的DC1 ip相同,mDeviceConnectionMap覆盖重复查询问题 
3.新增心跳检测,15秒未通讯关闭channel
4.关闭channel时,将DC1 online置为false,以便客户端显示离线状态